### PR TITLE
Update SrtWriter.hx

### DIFF
--- a/src/srt/SrtWriter.hx
+++ b/src/srt/SrtWriter.hx
@@ -19,16 +19,58 @@ class SrtWriter {
 		while (it < usm.length) {
 			if (usm[it].isSbt == true) {
 				o.writeString((it + 1) + '\r\n'); // number
+				
 				var startTime = Std.string(usm[it].startTime);
-				var padStartTime = startTime.lpad('0', 9);
+				var padstartTime = startTime.lpad('0', 9);
+				var startTimeInt = (usm[it].startTime); // creates an Int copy of the duration. 				
+				
+				if(startTimeInt >= 100000) startTimeInt = (startTimeInt + 40000);
+				if(startTimeInt >= 200000) startTimeInt = (startTimeInt + 40000);
+				if(startTimeInt >= 300000) startTimeInt = (startTimeInt + 40000);
+				if(startTimeInt >= 400000) startTimeInt = (startTimeInt + 40000);
+				if(startTimeInt >= 500000) startTimeInt = (startTimeInt + 40000);
+				if(startTimeInt >= 600000) startTimeInt = (startTimeInt + 40000); // adds an additional 40 seconds every 100 seconds because a start time of 100 gets written as 1:00 in the srt file which is 60 seconds. 
+				if(startTimeInt >= 700000) startTimeInt = (startTimeInt + 40000);
+				if(startTimeInt >= 800000) startTimeInt = (startTimeInt + 40000);
+				if(startTimeInt >= 900000) startTimeInt = (startTimeInt + 40000);
+				if(startTimeInt >= 1000000) startTimeInt = (startTimeInt + 40000);
+				if(startTimeInt >= 1100000) startTimeInt = (startTimeInt + 40000);
+				if(startTimeInt >= 1200000) startTimeInt = (startTimeInt + 40000);				
+								
+				var startTimeString = Std.string(startTimeInt); // converts the int to a string
+				var padStartTime = startTimeString.lpad('0', 9); // creates the array of endTimeString
 				o.writeString(padStartTime.substring(0, 2) + ':' + padStartTime.substring(2, 4) + ':' + padStartTime.substring(4, 6) + ','
 					+ padStartTime.substring(6, 9));
-				o.writeString(' --> ');
+					
+				o.writeString(' --> ');				
+				
 				var endTime = Std.string(usm[it].endTime);
 				var padEndTime = endTime.lpad('0', 9);
+				
+				var endTimeInt = (usm[it].endTime); // creates an Int copy of the duration. 
+				var endTime; // Leaves endTime empty for now.
+				endTimeInt = (endTimeInt + startTimeInt); // adds the start time and the duration to get the new end time				
+				
+				if (startTimeInt < 100000 && endTimeInt >= 100000 ) endTimeInt = (endTimeInt + 40000);
+				if (startTimeInt < 200000 && endTimeInt >= 200000 ) endTimeInt = (endTimeInt + 40000); 
+				if (startTimeInt < 300000 && endTimeInt >= 300000 ) endTimeInt = (endTimeInt + 40000);
+				if (startTimeInt < 400000 && endTimeInt >= 400000 ) endTimeInt = (endTimeInt + 40000);
+				if (startTimeInt < 500000 && endTimeInt >= 500000 ) endTimeInt = (endTimeInt + 40000); // adds an offset for if the start time is like 99 seconds and the end time is over 100 seconds
+				if (startTimeInt < 600000 && endTimeInt >= 600000 ) endTimeInt = (endTimeInt + 40000);  // enabling the end time to correctly be written in the .srt file
+				if (startTimeInt < 700000 && endTimeInt >= 700000 ) endTimeInt = (endTimeInt + 40000);
+				if (startTimeInt < 800000 && endTimeInt >= 800000 ) endTimeInt = (endTimeInt + 40000);
+				if (startTimeInt < 900000 && endTimeInt >= 900000 ) endTimeInt = (endTimeInt + 40000);
+				if (startTimeInt < 1000000 && endTimeInt >= 1000000 ) endTimeInt = (endTimeInt + 40000); 
+				if (startTimeInt < 1100000 && endTimeInt >= 1100000 ) endTimeInt = (endTimeInt + 40000);
+				if (startTimeInt < 1200000 && endTimeInt >= 1200000 ) endTimeInt = (endTimeInt + 40000);				
+				
+				var endTimeString = Std.string(endTimeInt); // converts the int to a string
+				var padEndTime = endTimeString.lpad('0', 9); // creates the array of endTimeString
+				
 				o.writeString(padEndTime.substring(0, 2) + ':' + padEndTime.substring(2, 4) + ':' + padEndTime.substring(4, 6) + ','
 					+ padEndTime.substring(6, 9));
 				o.writeString('\r\n');
+				
 				var newText = usm[it].text.replace('\x00', '');
 				newText = usm[it].text.replace('\\n', '\n');
 				o.writeString(newText + '\r\n\r\n');


### PR DESCRIPTION
This fixes some issues with the .srt writer file. it fixes the end time because in the @SBT the "end time" is actually just a duration of the subtitle but .srt files define the end time as a timestamp, not a duration so this adds the end time duration to the start time to get a correct end time before writing it to the .srt. before it would just write the duration as the end time and that would result in subtitles that are for example, -2 seconds long and just wouldnt play. 

it also fixes an issue where anything over 100 seconds gets messed up due to the .srt file going from 0:99 start time to 1:00 start time in the file which is 1 minute and is therefore 40 seconds behind the 100 second actual start time of the timestamp. this accounts for adding 40 seconds every 100 seconds to the start time and accounts for .usms up to 20 minutes long